### PR TITLE
Add Ona skills and auto-install in workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.ona/skills-private/

--- a/.ona/skills/ft-commit-conventions/SKILL.md
+++ b/.ona/skills/ft-commit-conventions/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ft-commit-conventions
+description: Enforces Filip's commit and naming conventions. PR titles use `[component]` prefixes, branch names use `ft/` prefix, and code references use backticks. Use when committing, creating branches, or raising PRs. Triggers on any git commit, branch creation, or PR workflow.
+---
+
+# Commit & Naming Conventions
+
+Apply these conventions to all git operations in this workspace.
+
+## PR Titles
+
+Format: `[component] description`
+
+Use bracket prefixes indicating the component(s) changed. Multiple components are comma-separated.
+
+Examples:
+- `[dashboard] fix account dropdown`
+- `[backend/api,dashboard] improve watching events`
+- `[flags] update feature flag defaults`
+
+Feature flag update PRs always use a `[flags]` prefix.
+
+## Branch Naming
+
+Format: `ft/<brief-descriptive-name>`
+
+Keep branch names brief but not over-shortened. The prefix is always `ft`.
+
+Examples:
+- `ft/fix-account-dropdown`
+- `ft/improve-watch-events`
+
+## Code References in Text
+
+When mentioning code in PR titles, commit messages, or comments:
+- Use backticks for variable names, component names, function names, etc.
+- Refer to React components as `<Component>` to make it clear it's a component.
+
+Examples:
+- "Update `handleSubmit` to validate input"
+- "Fix `<AccountDropdown>` overflow issue"
+
+## General
+
+- Always include `Co-authored-by: Ona <no-reply@ona.com>` when Ona is involved.
+- Do not include comments that compare new state to old state. Treat comments as describing the current state — something a newjoiner would read.

--- a/.ona/skills/ft-pr-workflow/SKILL.md
+++ b/.ona/skills/ft-pr-workflow/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ft-pr-workflow
+description: Enforces Filip's PR workflow conventions. Covers force-push policy, comment resolution, draft vs ready PRs, stacked PR ordering, and changelog discipline. Use when creating PRs, addressing review comments, or planning stacked changes. Triggers on PR creation, PR review, comment resolution, or push decisions.
+---
+
+# PR Workflow
+
+Apply these conventions when working with pull requests.
+
+## Force-Push Policy
+
+Do not force-push unless explicitly instructed. Amends and history rewrites are fine for local-only changes that haven't been pushed.
+
+## Push Policy
+
+When iterating on non-trivial changes (e.g. frontend layout changes), do not automatically push to the PR. Wait to be asked.
+
+Exception: when only resolving merge conflicts on an ongoing PR, pushing to get it into a mergeable state is fine.
+
+## Draft vs Ready
+
+- Trivial changes: raise as "ready for review" by default.
+- Non-trivial changes: raise as draft.
+
+## Addressing PR Comments
+
+When addressing a PR comment, never resolve it unless one of the following is true:
+1. The comment is not applicable — include reasoning when resolving.
+2. The comment is not actionable (praise, technical observations, questions — generally don't mark questions as resolved).
+3. You first reply in the thread with something like "Fixed in {commit_hash}".
+
+When replying to conversations on the author's behalf (through GitHub), prefix the message with `🤖` to make attribution clear.
+
+## Stacked PRs
+
+Prefer top-down PR ordering over bottom-up when building stacked changes.
+
+- Top-down: wire the full call path early (even with stubs/no-op handlers), fill in implementation in follow-up PRs.
+- Bottom-up defers integration to the end, increasing risk.
+
+Smells that suggest bottom-up is creeping in:
+- Functions or types introduced in a PR but unused in any real code path.
+- A PR that changes no observable behavior in production code.
+
+When planning a stack, ask: "Can I wire this end-to-end first with stubs, and iterate on the details after?"
+
+## Changelog
+
+Most changes do not need changelog entries. Be very selective about what to add.

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,40 @@ fi
 npm i -g vsce ovsx
 curl -fsSL https://bun.sh/install | bash
 
+# Install Ona skills into all workspaces
+if [ -n "$(ls -A /workspaces 2>/dev/null)" ]; then
+    for dir in /workspaces/*/; do
+        # Copy public skills
+        if [ -d "$SCRIPT_DIR/.ona/skills" ]; then
+            echo -e "\033[32mInstalling public Ona skills in ${dir}\033[0m"
+            mkdir -p "${dir}.ona/skills"
+            cp -r "$SCRIPT_DIR/.ona/skills/"* "${dir}.ona/skills/." 2>/dev/null || echo "Could not copy public skills to ${dir}"
+        fi
+
+        # Clone private skills into gitpod-next workspaces
+        workspace_name=$(basename "$dir")
+        if [ "$workspace_name" = "gitpod-next" ]; then
+            echo -e "\033[33mCloning private Ona skills into ${dir}\033[0m"
+            mkdir -p "${dir}.ona/skills"
+            if gh repo clone filiptronicek/ona-monorepo-skills /tmp/ona-monorepo-skills -- --depth 1 2>/dev/null; then
+                cp -r /tmp/ona-monorepo-skills/skills/* "${dir}.ona/skills/." 2>/dev/null || echo "Could not copy private skills to ${dir}"
+                rm -rf /tmp/ona-monorepo-skills
+            else
+                echo "Could not clone filiptronicek/ona-monorepo-skills (repo may not exist yet)"
+            fi
+        fi
+
+        # Exclude .ona/skills from git tracking without modifying .gitignore
+        if [ -d "${dir}.git" ]; then
+            exclude_file="${dir}.git/info/exclude"
+            mkdir -p "${dir}.git/info" 2>/dev/null
+            if ! grep -qxF '.ona/skills/' "$exclude_file" 2>/dev/null; then
+                echo '.ona/skills/' >> "$exclude_file"
+            fi
+        fi
+    done
+fi
+
 # Install oh-my-zsh
 KEEP_ZSHRC=yes sh -c "$(wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)"
 


### PR DESCRIPTION
Public skills (`ft-commit-conventions`, `ft-pr-workflow`) are committed here and copied into every workspace during `install.sh`. Private skills (e.g. `ft-code-review`) live in `filiptronicek/ona-monorepo-skills` and are cloned only into `gitpod-next` workspaces.

Skills are excluded from project git tracking via `.git/info/exclude` so they don't pollute project repos.